### PR TITLE
Add support for CH340 on MacOSX

### DIFF
--- a/analyzer/mainwindow.cpp
+++ b/analyzer/mainwindow.cpp
@@ -415,7 +415,7 @@ void MainWindow::Slot_menuDevice_Show()
 {
   unsigned int i;
   //QDir dir("/dev","ttyUSB*");
-  QDir dir("/dev","ttyUSB*;tty.usbserial*;rfcomm*",QDir::Name | QDir::IgnoreCase,QDir::System);
+  QDir dir("/dev","ttyUSB*;tty.usbserial*;rfcomm*;tty.wchusbserial*",QDir::Name | QDir::IgnoreCase,QDir::System);
 
 printf("dir: %d\n",dir.count());
   ui->menuDevice->clear();


### PR DESCRIPTION
CH340 serial converter is getting more popular in Sark100 clones, 
so it should be on a whitelist.